### PR TITLE
hotfix-types-cli

### DIFF
--- a/src/xllm/core/config.py
+++ b/src/xllm/core/config.py
@@ -84,7 +84,7 @@ class HuggingFaceConfig:
             "help": "HuggingFace Hub token. You can also set this key using .env file",
         },
     )
-    deepspeed_stage: Union[int, str, None] = field(
+    deepspeed_stage: Optional[int] = field(
         default=0,
         metadata={
             "help": "DeepSpeed stage",
@@ -439,9 +439,7 @@ class HuggingFaceConfig:
             "evaluation can be performed, depending on the evaluation_strategy"
         },
     )
-    eval_steps: Union[int, float, None] = field(
-        default=1000, metadata={"help": "Number of update steps between two evaluations"}
-    )
+    eval_steps: Optional[int] = field(default=1000, metadata={"help": "Number of update steps between two evaluations"})
     warmup_steps: int = field(
         default=1000,
         metadata={


### PR DESCRIPTION
## Description

Solve this exception:

ValueError: Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because the argument parser only supports one type per argument. Problem encountered in field 'eval_steps'.

<!-- Link to Notion sprint -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
